### PR TITLE
Fix link-time errors on Linux; improve Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *~
+buttonbox

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
+# Makefile for buttonbox
+
+# Define the variables conventionally used for the C compiler and linker
+CFLAGS = $(shell sdl2-config --cflags)
+LDLIBS = $(shell sdl2-config --libs) -lm
+CC     = gcc
+
+# Rule to make buttonbox.  Note that on Linux Mint, and probably most Linuxes,
+#	libraries need to come after the object files that use them.  That's
+#	so that the linker can load only the functions that are actually used.
 buttonbox: keyboard.c synthesis.c config.c display.c main.c
-	gcc `sdl2-config --cflags --libs` -o buttonbox main.c
+	$(CC) $(CFLAGS) -o $@ main.c $(LDLIBS)


### PR DESCRIPTION
The original build recipe gave lots of undefined symbols at link time (building on Linx Mint 21.1 Vera); it turned out that the linker (GNU ln) loads object files and libraries in the order they're given on the command line.  That means that the libraries have to come _after_ the source files on the gcc command line.

The implicit rule for building from C sources uses two make variables, CFLAGS at the beginning of the line, and LDLIBS at the end.  So I added those to the Makefile, along with the conventional CC for the C compiler.  These changes will almost certainly work on Windows and Mac; I don't think I used any GNU make features.  But I haven't tested it.

This commit also adds a local `.gitignore` file to keep the binary file from being accidentally added to the repository.